### PR TITLE
feat: Amenoma support

### DIFF
--- a/main.py
+++ b/main.py
@@ -171,7 +171,7 @@ def parse_cli_sort_string(sort_str_list):
     return sort_rule_list
 
 
-def generate_g2c_artifact_from_good(good_artifact):
+def generate_g2c_artifact_from_good(index, good_artifact):
     """Generate G2C artifact structure from GOOD artifact structure
 
     :param good_artifact: GOOD (Genshin Open Object Description) artifact structure
@@ -179,7 +179,7 @@ def generate_g2c_artifact_from_good(good_artifact):
     """
     return {
         'id': str(uuid.uuid4()),
-        'refer_id': good_artifact.get('Id', ''),
+        'refer_id': good_artifact.get('Id', index),
         'set_key': good_artifact['setKey'],
         'slot_key': good_artifact['slotKey'],
         'main_stat_key': good_artifact['mainStatKey'],
@@ -202,7 +202,7 @@ def generate_g2c_artifact_list_from_good(good_artifact_list):
     :param good_artifact_list: GOOD (Genshin Open Object Description) artifact list
     :return: G2C (Genshin Garbage Collector) artifact list
     """
-    return [generate_g2c_artifact_from_good(artifact) for artifact in good_artifact_list]
+    return [generate_g2c_artifact_from_good(idx, artifact) for idx, artifact in enumerate(good_artifact_list)]
 
 
 def hydrate_sub_stats_efficiency(g2c_artifact_list):


### PR DESCRIPTION
I've been having less success lately with Inventory Kamera for scanning artifacts.. so I've been using Amenoma for a while.
However, they don't fill in an id parameter for us to keep the artifact order.

This PR simply makes the program fallback to the JSON order whenever the "id" parameter isn't present.

And by the way, thanks for the great work on this repo.